### PR TITLE
Python 3 compatibility

### DIFF
--- a/pymtp/main.py
+++ b/pymtp/main.py
@@ -829,7 +829,7 @@ class MTP:
 
 			# Check if this ID exists, if not, add it
 			# and trigger a scan of the children
-			if not (ret.has_key(next.folder_id)):
+			if next.folder_id not in ret:
 				ret[next.folder_id] = next
 				scanned = False
 
@@ -871,7 +871,7 @@ class MTP:
 		while True:
 			next = next.contents
 			## Check if this folder is in the dict
-			if not (tmp.has_key(next.folder_id)):
+			if next.folder_id not in tmp:
 				tmp[next.folder_id] = next
 
 			# Check for siblings


### PR DESCRIPTION
The current version of `pymtp` only works when using Python2. This as the `has_key()` function of dictionaries is removed in Python3 (see [this](https://portingguide.readthedocs.io/en/latest/dicts.html)). Replacing the two occurrences of this construct by `in` makes the module work* in both Python2 and Python3.  

This same fix can also be found in `py3mtp` [[link](https://sourceforge.net/projects/py3mtp/)]

*It compiles and runs, but behaviour is slightly different due to changes in `ctypes`